### PR TITLE
Fixed

### DIFF
--- a/wildfly-base/src/main/docker/standalone-uvms.xml
+++ b/wildfly-base/src/main/docker/standalone-uvms.xml
@@ -211,7 +211,7 @@
                         <password>sa</password>
                     </security>
                 </datasource>
-                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_audit" pool-name="jdbc/uvms_audit" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_audit" pool-name="jdbc/uvms_audit" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -234,7 +234,7 @@
                         <password>audit</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_mobterm" pool-name="jdbc/uvms_mobterm" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_mobterm" pool-name="jdbc/uvms_mobterm" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -257,7 +257,7 @@
                         <password>mobterm</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_movement" pool-name="jdbc/uvms_movement" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_movement" pool-name="jdbc/uvms_movement" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -280,7 +280,7 @@
                         <password>movement</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_asset" pool-name="jdbc/uvms_asset" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_asset" pool-name="jdbc/uvms_asset" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -303,7 +303,7 @@
                         <password>asset</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_exchange" pool-name="jdbc/uvms_exchange" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_exchange" pool-name="jdbc/uvms_exchange" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -326,7 +326,7 @@
                         <password>exchange</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_rules" pool-name="jdbc/uvms_rules" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_rules" pool-name="jdbc/uvms_rules" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -349,7 +349,7 @@
                         <password>rules</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_usm" pool-name="uvms_usm" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_usm" pool-name="uvms_usm" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -372,7 +372,7 @@
                         <password>usm</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:/jdbc/USM2" pool-name="jdbc/USM2" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:/jdbc/USM2" pool-name="jdbc/USM2" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -395,7 +395,7 @@
                         <password>usm</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_spatial" pool-name="uvms_spatial" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_spatial" pool-name="uvms_spatial" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -418,7 +418,7 @@
                         <password>spatial</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_reporting" pool-name="uvms_reporting" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_reporting" pool-name="uvms_reporting" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -441,7 +441,7 @@
                         <password>reporting</password>
                     </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_activity" pool-name="uvms_activity" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_activity" pool-name="uvms_activity" enabled="true" use-ccm="true" statistics-enabled="false">
                      <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
                      <xa-datasource-property name="PortNumber">5432</xa-datasource-property>
                      <xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -464,7 +464,7 @@
                          <password>activity</password>
                      </security>
                  </xa-datasource>
-                 <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_mdr" pool-name="uvms_mdr" enabled="true" use-ccm="true" statistics-enabled="true">
+                 <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_mdr" pool-name="uvms_mdr" enabled="true" use-ccm="true" statistics-enabled="false">
                      <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
                      <xa-datasource-property name="PortNumber">5432</xa-datasource-property>
                      <xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -487,7 +487,7 @@
                          <password>mdr</password>
                      </security>
                  </xa-datasource>
-                 <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_sales" pool-name="uvms_sales" enabled="true" use-ccm="true" statistics-enabled="true">
+                 <xa-datasource jta="true" jndi-name="java:jboss/datasources/uvms_sales" pool-name="uvms_sales" enabled="true" use-ccm="true" statistics-enabled="false">
                      <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
                      <xa-datasource-property name="PortNumber">5432</xa-datasource-property>
                      <xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -510,7 +510,7 @@
                          <password>sales</password>
                      </security>
                 </xa-datasource>
-                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_config" pool-name="jdbc/uvms_config" enabled="true" use-ccm="true" statistics-enabled="true">
+                <xa-datasource jta="true" jndi-name="java:/jdbc/uvms_config" pool-name="jdbc/uvms_config" enabled="true" use-ccm="true" statistics-enabled="false">
                     <xa-datasource-property name="ServerName">postgres</xa-datasource-property>
     				<xa-datasource-property name="PortNumber">5432</xa-datasource-property>
     				<xa-datasource-property name="DatabaseName">db71u</xa-datasource-property>
@@ -1018,7 +1018,7 @@
                 </process-id>
             </core-environment>
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
-            <coordinator-environment default-timeout="600" statistics-enabled="true"/>            
+            <coordinator-environment default-timeout="3600" statistics-enabled="false"/>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:undertow:1.2">
             <buffer-cache name="default"/>


### PR DESCRIPTION
       TransactionTimeOut time so that deploying long startup modules (like Rules) doesn't fail
       Disabled statistics because wildfly 8.2 has bux related to it (persistence unit nullpointer during redeploy)