### PR TITLE
Update ActiveMQ resource adapter to 5.15.4

### DIFF
--- a/wildfly-base/pom.xml
+++ b/wildfly-base/pom.xml
@@ -18,7 +18,7 @@
 		<wildfly.hibernate.module.jts.version>1.13</wildfly.hibernate.module.jts.version>		
 		<wildfly.postgres.module.postgis.version>1.5.3</wildfly.postgres.module.postgis.version>
 		<wildfly.postgres.module.postgres.version>42.1.4.jre7</wildfly.postgres.module.postgres.version>
-		<wildfly.activemq.rar.version>5.14.5</wildfly.activemq.rar.version>
+		<wildfly.activemq.rar.version>5.15.4</wildfly.activemq.rar.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
The latest version of the ActiveMQ resource adapter contains a fix for leaked connection threads.

See the issue here:
https://issues.jboss.org/browse/ENTMQ-2110

And the actual commit that fixed it:
https://github.com/apache/activemq/commit/f304205918794b8f76e76d930cb8137c2f9fadd2

@gregoryrinaldi make sure to update the version of the resource adapter in your acceptance/prod environment too


