### PR TITLE
Upgrade activemq to 5.15.4

### DIFF
--- a/amq/src/main/docker/Dockerfile
+++ b/amq/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rmohr/activemq:5.14.5-alpine
+FROM rmohr/activemq:5.15.4-alpine
 
 COPY activemq.xml users.properties env /opt/$ACTIVEMQ/conf/
 

--- a/foundation-test/pom.xml
+++ b/foundation-test/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>org.apache.activemq</groupId>
 			<artifactId>activemq-client</artifactId>
-			<version>5.14.5</version>			
+			<version>5.15.4</version>
 		</dependency>
 		<dependency>
 			<artifactId>mobileterminal-model</artifactId>

--- a/unionvms-wildfly-dist/src/main/assembly/assembly.xml
+++ b/unionvms-wildfly-dist/src/main/assembly/assembly.xml
@@ -95,7 +95,7 @@
 	</fileSets>
 	<files>
 		<file>
-			<source>target/content/uvms-docker-wildfly-base/deployments/activemq-rar-5.14.5.rar
+			<source>target/content/uvms-docker-wildfly-base/deployments/activemq-rar-5.15.4.rar
 			</source>
 			<outputDirectory>standalone/deployments</outputDirectory>
 			<destName>activemq-rar.rar</destName>

--- a/wildfly-base/pom.xml
+++ b/wildfly-base/pom.xml
@@ -18,7 +18,7 @@
 		<wildfly.hibernate.module.jts.version>1.13</wildfly.hibernate.module.jts.version>		
 		<wildfly.postgres.module.postgis.version>1.5.3</wildfly.postgres.module.postgis.version>
 		<wildfly.postgres.module.postgres.version>42.1.4.jre7</wildfly.postgres.module.postgres.version>
-		<wildfly.activemq.rar.version>5.14.5</wildfly.activemq.rar.version>
+		<wildfly.activemq.rar.version>5.15.4</wildfly.activemq.rar.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
The latest version of the ActiveMQ resource adapter contains a fix for leaked connection threads.

See the issue here:
https://issues.jboss.org/browse/ENTMQ-2110

And the actual commit that fixed it:
apache/activemq@f304205